### PR TITLE
Add the "cancel previous runs" CI step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,10 @@ jobs:
       matrix:
         tox-env: [lint, type, apidoc-check]
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout latest commit
         uses: actions/checkout@v2
         with:
@@ -44,6 +48,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.8]
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout latest commit
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Fixes #34 

## Description

This adds [an additional action](https://github.com/marketplace/actions/cancel-workflow-action) to the CI that cancels all previous CI runs.

## How to test?

Make several consecutive commits to a branch, check that the CI is only being run for the last commit and is cancelled for all previous ones.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/morphoclass/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] `setup.cfg`, `requirements.txt`, and `constraints.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [ ] All CI tests pass. 
