### PR TITLE
Inter-rater agreement data for Janelia Pyramidal Cells Layer 5

### DIFF
--- a/dvc/data/raw/README.md
+++ b/dvc/data/raw/README.md
@@ -17,7 +17,7 @@ This is a dataset of pyramidal cells obtained from Ying via Lida.
   selected to compose a dataset. This dataset is represented by the file
   `selected_dataset.csv`.
 
-### `janelia/inter-rater`
+### Janelia inter-rater annotations `janelia/inter-rater`
 
 All the "ground truth" labels used in this project for training and evaluation
 purposes were provided by Ying Shi. But in order to estimate the inter-rater

--- a/dvc/data/raw/README.md
+++ b/dvc/data/raw/README.md
@@ -16,3 +16,18 @@ This is a dataset of pyramidal cells obtained from Ying via Lida.
 * Based on the notes in both Excel-files a subset of morphology files was
   selected to compose a dataset. This dataset is represented by the file
   `selected_dataset.csv`.
+
+### `janelia/inter-rater`
+
+All the "ground truth" labels used in this project for training and evaluation
+purposes were provided by Ying Shi. But in order to estimate the inter-rater
+agreement between different experts, Julie Meystre also provided her own labels
+(independently and without knowing anything about Ying Shi's labels) on the
+Layer 5 Janelia pyramidal cells.
+* `Classification_JulieM.xlsx` - This is the original Excel spreadsheet
+  provided by Julie Meystre, including her labels as well as per-sample
+  comments (in free text format).
+* `inter_rater-janelia-l5-ying_shi-julie_meystre.csv` - This is a CSV file
+  derived from the aforementioned Excel spreadsheet. It summarizes the
+  information about the labels given by the two human experts, in order to
+  allow for easy evaluation of the inter-rater agreement.

--- a/dvc/data/raw/janelia.dvc
+++ b/dvc/data/raw/janelia.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 627ac4dd5a7f64baa17611a837e9d19e.dir
-  size: 1308039306
-  nfiles: 187
+- md5: 976a60b2401723f91ca91136acd3d223.dir
+  size: 1308040898
+  nfiles: 188
   path: janelia

--- a/dvc/data/raw/janelia.dvc
+++ b/dvc/data/raw/janelia.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: ff5aeeb9894bb4957999d3ff1e202b0f.dir
-  size: 1308022271
-  nfiles: 186
+- md5: 627ac4dd5a7f64baa17611a837e9d19e.dir
+  size: 1308039306
+  nfiles: 187
   path: janelia


### PR DESCRIPTION
Fixes #25.

## Description

Two files are added:
* `Classification_JulieM.xlsx` - This is the original Excel spreadsheet provided by Julie Meystre, including her labels as well as per-sample comments (in free text format).
* `inter_rater-janelia-l5-ying_shi-julie_meystre.csv` - This is a CSV file derived from the aforementioned Excel spreadsheet. It summarizes the information about the labels given by the two human experts, in order to allow for easy evaluation of the inter-rater agreement.


## How to test?

Fetch the data from DVC remote:
`
cd dvc/data/raw
dvc pull janelia
`
Then you should see two new files under the `inter-rater` folder:
```
janelia
├── inter-rater
│   ├── Classification_JulieM.xlsx
│   └── inter_rater-janelia-l5-ying_shi-julie_meystre.csv
```

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/morphoclass/issues).
  (if it is not the case, please create an issue first).
- [x] All CI tests pass. 
