### PR TITLE
Compute balanced accuracy metric

### DIFF
--- a/src/morphoclass/console/performance_table.py
+++ b/src/morphoclass/console/performance_table.py
@@ -111,10 +111,15 @@ def make_performance_table(
     cell_style = "padding-right: 1em; white-space: nowrap;"
     df_style.set_table_styles([{"selector": "th, td", "props": cell_style}])
 
-    # generate a HTML report
+    # generate a HTML table report
     template = mc.report.plumbing.load_template("results-table")
     mc.report.plumbing.render(template, {"df_results": df_style.render()}, results_file)
-    logger.info(f"Report stored in: {results_file.resolve().as_uri()}")
+    logger.info(f"HTML table written in: {results_file.resolve().as_uri()}")
+
+    # generate a CSV table report
+    results_csv = results_file.with_suffix(".csv")
+    df.to_csv(results_csv, index=False)
+    logger.info(f"CSV table written in: {results_csv.resolve().as_uri()}")
 
     logger.info("Done.")
 

--- a/src/morphoclass/console/performance_table.py
+++ b/src/morphoclass/console/performance_table.py
@@ -151,11 +151,10 @@ def make_report_row(data: dict) -> dict:
     # Compute balanced accuracy here, because training.cli.collect_metrics() lacks it.
     balanced_accuracy_vals = []
     for split in data["splits"]:
-        balanced_accuracy_vals.append(
-            balanced_accuracy_score(
-                y_true=split["ground_truths"], y_pred=split["predictions"]
-            )
-        )
+        y_true = split["ground_truths"]
+        y_pred = split["predictions"]
+        balanced_accuracy_vals.append(balanced_accuracy_score(y_true, y_pred))
+
     data["balanced_accuracy_mean"] = np.mean(balanced_accuracy_vals)
     data["balanced_accuracy_std"] = np.std(balanced_accuracy_vals)
 


### PR DESCRIPTION
Fixes #27.

## Description

1. The table created by ` morphoclass performance-table` now contains a `"balanced_accuracy"` column.
2. The table is now written both to the HTML report _and_ to a CSV file (for further manipulation, in view of the paper).

## TODO

- [ ] All metrics should be computed in the `make_performance_table()` function (even though they are already written in the checkpoint at training time).

## How to test?

Please provide here instructions on how to test the changes introduced by this PR.
(if some changes cannot be tested by automated tests)

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/morphoclass/issues).
  (if it is not the case, please create an issue first).
- [x] All CI tests pass. 
