### PR TITLE
Remove manual install of `wheels` and `setuptools` from `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-echo "Installing/upgrading pip, wheel, setuptools"
-pip install -U pip wheel setuptools
-
 echo "Installing morphoclass"
 pip install . -c constraints.txt
 


### PR DESCRIPTION
Fixes #16

## Description

Some of our package dependencies need `wheels` and `setuptools` in order to be `pip`-installed. So we want these two packages to be available at build time **before** the `setup.py` is run by `pip install morphoclass`. For this reason we have this in our `pyproject.toml`:
https://github.com/BlueBrain/morphoclass/blob/bd28c2ea217b6d479afd1d43afdd6f1253638f32/pyproject.toml#L1-L7

However, notice that we don't really need `setuptools` or `wheel` anywhere in our source code. So we don't need to add them to our `install_requires` in the `setup.cfg`
https://github.com/BlueBrain/morphoclass/blob/bd28c2ea217b6d479afd1d43afdd6f1253638f32/setup.cfg#L24
and, for the same reason, we don't need to manually `pip install` those two packages before `pip install morphoclass` in our `install.sh`.

#### TL;DR

The two packages `setuptools` and `wheel` are needed at build time to `pip`-install some other packages that `morphoclass` depends on. But these two packages are not needed afterwards.

This the typical use case for having these packages in the `build-system.requires` of `pyproject.toml`, and nowhere wlse.

See also [PEP-517](https://peps.python.org/pep-0517) and [PEP-518](https://peps.python.org/pep-0518).

## How to test?
Run with very verbose options:
```bash
pip install -vvv -e .
```
and everything should be installed w/o issues. Also, you should read in the output something like
```bash
Installing collected packages: wheel, tomli, setuptools, pyparsing, pip, packaging, setuptools_scm
    Creating /tmp/pip-build-env-o7xza0n8/overlay/bin
    changing mode of /tmp/pip-build-env-o7xza0n8/overlay/bin/wheel to 755
    ...
```
which clearly shows that `wheel` is being installed (with the other `build-system.requires`) in a temporary directory which is only used at build time by `pip install`, instead of being installed under the usual `./venv/lib/python3.8/site-packages`.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/morphoclass/issues).
  (if it is not the case, please create an issue first).
- [x] All CI tests pass. 
