### PR TITLE
Use StrPath for arguments of pathlib.Path()

### DIFF
--- a/src/morphoclass/console/cmd_evaluate.py
+++ b/src/morphoclass/console/cmd_evaluate.py
@@ -15,10 +15,11 @@
 from __future__ import annotations
 
 import logging
-import os
 import pathlib
 
 import click
+
+from morphoclass.types import StrPath
 
 logger = logging.getLogger(__name__)
 
@@ -40,9 +41,7 @@ def cli():
 )
 @click.argument("checkpoint_path", type=click.Path(dir_okay=False, exists=True))
 @click.argument("report_path", type=click.Path(dir_okay=False, exists=False))
-def performance(
-    checkpoint_path: str | os.PathLike, report_path: str | os.PathLike
-) -> None:
+def performance(checkpoint_path: StrPath, report_path: StrPath) -> None:
     """Run the `evaluate performance` subcommand."""
     logger.info("Setting up paths")
     checkpoint_path = pathlib.Path(checkpoint_path)
@@ -84,9 +83,7 @@ def performance(
 )
 @click.argument("checkpoint_path", type=click.Path(dir_okay=False, exists=True))
 @click.argument("report_path", type=click.Path(dir_okay=False, exists=False))
-def latent_features(
-    checkpoint_path: str | os.PathLike, report_path: str | os.PathLike
-) -> None:
+def latent_features(checkpoint_path: StrPath, report_path: StrPath) -> None:
     """Run the `evaluate latent-features subcommand."""
     logger.info("Setting up paths")
     checkpoint_path = pathlib.Path(checkpoint_path)
@@ -135,9 +132,7 @@ def latent_features(
 )
 @click.argument("checkpoint_path", type=click.Path(dir_okay=False, exists=True))
 @click.argument("report_path", type=click.Path(dir_okay=False, exists=False))
-def outliers(
-    checkpoint_path: str | os.PathLike, report_path: str | os.PathLike
-) -> None:
+def outliers(checkpoint_path: StrPath, report_path: StrPath) -> None:
     """Run the `evaluate outliers` subcommand."""
     logger.info("Setting up paths")
     checkpoint_path = pathlib.Path(checkpoint_path)

--- a/src/morphoclass/console/cmd_extract_features.py
+++ b/src/morphoclass/console/cmd_extract_features.py
@@ -15,12 +15,13 @@
 from __future__ import annotations
 
 import logging
-import os
 import pathlib
 import re
 from typing import Literal
 
 import click
+
+from morphoclass.types import StrPath
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +96,7 @@ logger = logging.getLogger(__name__)
     help="Don't ask for overwriting existing output files.",
 )
 def cli(
-    csv_path: str | os.PathLike,
+    csv_path: StrPath,
     neurite_type: Literal["apical", "axon", "basal", "all"],
     feature: Literal[
         "graph-rd",
@@ -107,7 +108,7 @@ def cli(
         "image-tmd-proj",
         "image-deepwalk",
     ],
-    output_dir: str | os.PathLike,
+    output_dir: StrPath,
     orient: bool,
     no_simplify_graph: bool,
     keep_diagram: bool,

--- a/src/morphoclass/console/cmd_organise_dataset.py
+++ b/src/morphoclass/console/cmd_organise_dataset.py
@@ -20,6 +20,8 @@ import shutil
 
 import click
 
+from morphoclass.types import StrPath
+
 logger = logging.getLogger(__name__)
 
 
@@ -55,7 +57,7 @@ logger = logging.getLogger(__name__)
     required=True,
     help="Output directory path.",
 )
-def cli(input_csv_path: str, output_dir: str | pathlib.Path) -> None:
+def cli(input_csv_path: str, output_dir: StrPath) -> None:
     """Organizing ML data.
 
     Parameters

--- a/src/morphoclass/console/cmd_performance_report.py
+++ b/src/morphoclass/console/cmd_performance_report.py
@@ -15,9 +15,10 @@
 from __future__ import annotations
 
 import logging
-import pathlib
 
 import click
+
+from morphoclass.types import StrPath
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ logger = logging.getLogger(__name__)
     type=click.Path(exists=False, file_okay=False),
     help="The HTML report output directly.",
 )
-def cli(checkpoint_dir: str | pathlib.Path, output_dir: str | pathlib.Path) -> None:
+def cli(checkpoint_dir: StrPath, output_dir: StrPath) -> None:
     """Compile the table with models' results.
 
     Parameters

--- a/src/morphoclass/console/cmd_performance_table.py
+++ b/src/morphoclass/console/cmd_performance_table.py
@@ -15,10 +15,11 @@
 from __future__ import annotations
 
 import logging
-import pathlib
 from collections.abc import Sequence
 
 import click
+
+from morphoclass.types import StrPath
 
 logger = logging.getLogger(__name__)
 
@@ -45,9 +46,7 @@ logger = logging.getLogger(__name__)
     type=click.Path(exists=False, file_okay=False),
     help="The HTML report output directly.",
 )
-def cli(
-    checkpoint_paths: Sequence[str | pathlib.Path], output_dir: str | pathlib.Path
-) -> None:
+def cli(checkpoint_paths: Sequence[StrPath], output_dir: StrPath) -> None:
     """Compile the table with models' results.
 
     Parameters

--- a/src/morphoclass/console/cmd_train.py
+++ b/src/morphoclass/console/cmd_train.py
@@ -20,6 +20,8 @@ import pathlib
 import click
 import yaml
 
+from morphoclass.types import StrPath
+
 logger = logging.getLogger(__name__)
 
 
@@ -57,10 +59,10 @@ logger = logging.getLogger(__name__)
     help="Don't ask for overwriting existing output files.",
 )
 def cli(
-    features_dir: str | pathlib.Path,
-    model_config: str | pathlib.Path,
-    splitter_config: str | pathlib.Path,
-    checkpoint_dir: str | pathlib.Path,
+    features_dir: StrPath,
+    model_config: StrPath,
+    splitter_config: StrPath,
+    checkpoint_dir: StrPath,
     force: bool,
 ) -> None:
     """Training and evaluation of the model.

--- a/src/morphoclass/console/cmd_xai.py
+++ b/src/morphoclass/console/cmd_xai.py
@@ -15,12 +15,13 @@
 from __future__ import annotations
 
 import logging
-import os
 import pathlib
 import tempfile
 from datetime import datetime
 
 import click
+
+from morphoclass.types import StrPath
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ def cli():
     type=click.Path(file_okay=False),
     help="The XAI report output directory",
 )
-def report(checkpoint_path: str | os.PathLike, output_dir: str | os.PathLike) -> None:
+def report(checkpoint_path: StrPath, output_dir: StrPath) -> None:
     """Create an XAI report.
 
     Parameters

--- a/src/morphoclass/data/morphology_data.py
+++ b/src/morphoclass/data/morphology_data.py
@@ -14,11 +14,12 @@
 """Implementation of the MorphologyData class."""
 from __future__ import annotations
 
-import os
 from typing import TypeVar
 
 import torch
 from torch_geometric.data.data import Data
+
+from morphoclass.types import StrPath
 
 T = TypeVar("T", bound="MorphologyData")
 
@@ -51,13 +52,13 @@ class MorphologyData(Data):
         return data_dict
 
     @classmethod
-    def load(cls: type[T], path: str | os.PathLike) -> T:
+    def load(cls: type[T], path: StrPath) -> T:
         """Load a serialised data object from disk."""
         data_dict = torch.load(path)
         data_obj: T = cls.from_dict(data_dict)
         return data_obj
 
-    def save(self, path: str | os.PathLike) -> None:
+    def save(self, path: StrPath) -> None:
         """Serialise the data object to disk."""
         data_dict = self.to_dict()
         torch.save(data_dict, path)

--- a/src/morphoclass/report/xai.py
+++ b/src/morphoclass/report/xai.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import pathlib
 import textwrap
 
@@ -33,6 +32,7 @@ from morphoclass.data.morphology_data import MorphologyData
 from morphoclass.data.morphology_dataset import MorphologyDataset
 from morphoclass.report import plumbing
 from morphoclass.training.training_log import TrainingLog
+from morphoclass.types import StrPath
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 class XAIReport:
     """XAI report manager."""
 
-    def __init__(self, output_dir: str | os.PathLike) -> None:
+    def __init__(self, output_dir: StrPath) -> None:
         self.output_dir = pathlib.Path(output_dir).resolve()
         self.img_dir = self.output_dir / "images"
         self.sections: dict[str, str] = {}
@@ -189,9 +189,7 @@ def _restore_dataset(training_log):
     return dataset
 
 
-def _restore_neurites(
-    features_dir: str | os.PathLike, dataset: MorphologyDataset
-) -> None:
+def _restore_neurites(features_dir: StrPath, dataset: MorphologyDataset) -> None:
     """Restore TMD neurites for a features-only dataset."""
     # Get the neurite type that the features correspond to. Assuming that
     # the features dir has the form ".../<neurite-type>/<feature-type>"

--- a/src/morphoclass/training/training_config.py
+++ b/src/morphoclass/training/training_config.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 import dataclasses
 import importlib
-import os
 import pathlib
 from typing import Callable
 
 import yaml
+
+from morphoclass.types import StrPath
 
 
 @dataclasses.dataclass
@@ -111,7 +112,7 @@ class TrainingConfig:
         cls,
         conf_model: dict,
         conf_splitter: dict,
-        features_dir: str | os.PathLike,
+        features_dir: StrPath,
         workdir: pathlib.Path | None = None,
     ) -> TrainingConfig:
         """Construct a training config from separate configs."""

--- a/src/morphoclass/types.py
+++ b/src/morphoclass/types.py
@@ -25,7 +25,7 @@ from typing_extensions import Protocol
 #  imports, in particular from morphoclass and torch (above). Hopefully the
 #  protocol definition that requires these imports will be obsolete once the
 #  feature extraction in the DVC/CLI hs be propertly refactored.
-from morphoclass.data import MorphologyDataset
+import morphoclass.data
 
 # Starting py39 should write `os.PathLike[str]`
 # See also
@@ -45,5 +45,5 @@ class FeatureExtractor(Protocol):
         embedding_type: str,
         neurite_type: str | None = None,
         overwrite: bool = False,
-    ) -> tuple[MorphologyDataset, DataLoader, dict]:
+    ) -> tuple[morphoclass.data.MorphologyDataset, DataLoader, dict]:
         """Run the feature extractor."""


### PR DESCRIPTION
Fixes #51

## Description

Use `morphoclass.types.StrPath` everywhere (see #51 for details).

## How to test?

Running
```bash
git grep -rIEn "(str \||\| str)"
```
should return only
```text
dvc/training/make_configs.py:31:    optimizer_class: str | None = None
src/morphoclass/training/training_config.py:44:    neurite_type: str | None = None  # if None then fall back to default of dataset type
src/morphoclass/types.py:46:        neurite_type: str | None = None,
```

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/morphoclass/issues).
  (if it is not the case, please create an issue first).
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
