### PR TITLE
Fix CUDA Docker image bug + Improve Dockerfile + Add requirements-extra.txt

### DIFF
--- a/docker/morphoclass.Dockerfile
+++ b/docker/morphoclass.Dockerfile
@@ -4,7 +4,6 @@ ENV http_proxy="http://bbpproxy.epfl.ch:80"
 ENV https_proxy="http://bbpproxy.epfl.ch:80"
 ENV HTTP_PROXY="http://bbpproxy.epfl.ch:80"
 ENV HTTPS_PROXY="http://bbpproxy.epfl.ch:80"
-ENV PIP_INDEX_URL="https://bbpteam.epfl.ch/repository/devpi/simple"
 
 # Debian's default LANG=C breaks python3.
 # See commends in the official python docker file:

--- a/docker/morphoclass.Dockerfile
+++ b/docker/morphoclass.Dockerfile
@@ -31,7 +31,7 @@ python3.8 -m pip install --upgrade pip setuptools wheel && \
 update-alternatives --install /usr/local/bin/python python /usr/bin/python3.8 0
 
 # Install requirements
-COPY requirements*.txt /tmp
+COPY requirements*.txt /tmp/
 RUN \
 pip install -r /tmp/requirements.txt && \
 pip install -r /tmp/requirements-extras.txt

--- a/docker/morphoclass.Dockerfile
+++ b/docker/morphoclass.Dockerfile
@@ -31,8 +31,10 @@ python3.8 -m pip install --upgrade pip setuptools wheel && \
 update-alternatives --install /usr/local/bin/python python /usr/bin/python3.8 0
 
 # Install requirements
-COPY requirements.txt /tmp
-RUN pip install -r /tmp/requirements.txt
+COPY requirements*.txt /tmp
+RUN \
+pip install -r /tmp/requirements.txt &&
+pip install -r /tmp/requirements-extras.txt
 
 # Install torch geometric
 RUN \

--- a/docker/morphoclass.Dockerfile
+++ b/docker/morphoclass.Dockerfile
@@ -33,7 +33,7 @@ update-alternatives --install /usr/local/bin/python python /usr/bin/python3.8 0
 # Install requirements
 COPY requirements*.txt /tmp
 RUN \
-pip install -r /tmp/requirements.txt &&
+pip install -r /tmp/requirements.txt && \
 pip install -r /tmp/requirements-extras.txt
 
 # Install torch geometric

--- a/docker/morphoclass.Dockerfile
+++ b/docker/morphoclass.Dockerfile
@@ -11,7 +11,11 @@ ENV HTTPS_PROXY="http://bbpproxy.epfl.ch:80"
 ENV LANG=C.UTF-8
 ENV TZ="Europe/Zurich"
 
-# Install system packages
+# CUDA Linux Repo Key Rotation: https://github.com/NVIDIA/nvidia-docker/issues/1632#issuecomment-1112667716
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+
+#Install system packages
 RUN \
 apt-get update && \
 DEBIAN_FRONTEND="noninteractive" \

--- a/docs/source/sections/docker.rst
+++ b/docs/source/sections/docker.rst
@@ -62,7 +62,7 @@ external port set to ``35353``, and the container name to ``my-container``:
 
 .. code-block:: sh
 
-    docker run
+    docker run \
     --rm \
     -it \
     -u $USER \

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,0 +1,13 @@
+# --- docs ---
+Sphinx==4.5.0
+sphinx-bluebrain-theme==0.2.9
+sphinx-rtd-theme==1.0.0
+
+# --- dev ---
+dvc==2.10.2
+pre-commit==2.19.0
+pytest==7.1.2
+pytest-cov==3.0.0
+pytest-mock==3.7.0
+tox==3.25.0
+

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,5 +1,5 @@
 # --- docs ---
-Sphinx==4.5.0
+Sphinx==3.5.4
 sphinx-bluebrain-theme==0.2.9
 sphinx-rtd-theme==1.0.0
 


### PR DESCRIPTION
Fixes #63

## Description

1. Fix the `public key is not available: NO_PUBKEY` bug by using the workaround suggested in https://github.com/NVIDIA/nvidia-docker/issues/1632#issuecomment-1112667716
2. Remove `PIP_INDEX_URL` pointing at BBP internal Python index from the `Dockerfile` (otherwise `pip install neurots` will look for the wrong package in our index instead of PyPI!)
3. Introduce `requirements-extra.txt` to cover the requirements of `extras_require`.


## How to test?

1. Running `docker build` should now succeed.
3. Running `pip install .[dev,test]` inside the container should install `morphoclass` and confirm that all dependencies are already there.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/morphoclass/issues).
  (if it is not the case, please create an issue first).
- [x] `setup.cfg`, `requirements.txt`, and `constraints.txt` updated with new dependencies.
  (if needed)
- [ ] All CI tests pass. 
