### PR TITLE
Compute chance agreement on 'splits' instead of 'all'

### DIFF
--- a/src/morphoclass/console/performance_table.py
+++ b/src/morphoclass/console/performance_table.py
@@ -173,7 +173,9 @@ def make_report_row(data: dict) -> dict:
         row[metric_name] = f"{mean:.3f}±{std:.3f}"
 
     # Add chance agreement
-    chance_agreement_score = chance_agreement(data["all"]["ground_truths"])
+    chance_agreement_score = chance_agreement(
+        np.concatenate([split["ground_truths"] for split in data["splits"]])
+    )
     row["chance_agreement"] = f"{chance_agreement_score:.3f}"
 
     return row


### PR DESCRIPTION
Fixes #64 

## Description

With this PR, we compute `chance_agreement` using the `ground_truths` of the `"splits"` instead the  `ground_truth` of `"all"`, which may be missing, i.e. the solution proposed in https://github.com/BlueBrain/morphoclass/issues/64#issuecomment-1130009203.

Notice that there could be two ways to compute the `chance_agreement` based on the splits.
1. Compute `chance_agreement` on each `split`, then compute `mean` of the results to get an "average chance agreement"
2. Concatenate all `splits` and then compute `chance_agreement` to get a "global chance agreement"

For the computation of the various metrics (e.g. `accuracy`, `f1-score`, ...) in the `performance-table` CLI, we are following approach 1.
However, for `chance_agreement` in this PR we follow approach 2.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/morphoclass/issues).
  (if it is not the case, please create an issue first).
- [x] All CI tests pass. 
