### PR TITLE
Fix usage of `skip` in MCAR curation `luigi` configuration 

### DIFF
--- a/dvc/data/mcar-luigi.cfg
+++ b/dvc/data/mcar-luigi.cfg
@@ -21,11 +21,9 @@ nb_processes = 4
 
 ; Collect external dataset from a CSV file.
 [Collect]
-skip = false
 
 ; Detect which neurites are present in the morphology, and add soma if missing.
 [CheckNeurites]
-skip = false
 ensure_soma = true
 
 ; Sanitization is done with neuror.sanitize.sanitize and does:
@@ -36,10 +34,6 @@ ensure_soma = true
 ;    - raises if the morphology has a neurite whose type changes along the way
 ;    - removes segments with near zero lengths (shorter than 1e-4)
 [Sanitize]
-; TODO: this is being skipped because of the following bug:
-; https://github.com/BlueBrain/NeuroR/issues/99
-; Once the bug is fixed one should consider enabling this stage again
-skip = true
 
 ; Translate morphologies so that the soma is at (0, 0, 0).
 [Recenter]
@@ -49,7 +43,6 @@ skip = false
 ; If 'y' is provided (default value), not orientation will be applied.
 ; So this stage is a no-op?
 [Orient]
-skip = false
 
 ; Try to align using algorithms from morph_tool.transform.align_morphology
 ; Skip align as well. We don't want to rotate neurons, leave them as they are.

--- a/dvc/data/mcar-luigi.cfg
+++ b/dvc/data/mcar-luigi.cfg
@@ -78,3 +78,11 @@ min_range = 50
 [PlotErrors]
 skip = true
 with_plotly = true
+
+; Fix radius of the soma and cut the root section of neurites if needed.
+[EnsureNeuritesOutsideSoma]
+skip = true
+
+; Save error report for each morphology
+[ErrorsReport]
+skip = false


### PR DESCRIPTION
Fixes #71

## Description

1. All stages executed by MCAR curation `luigi` pipeline are now mentioned in the configuration file `mcar-luigi.cfg`.
2. This configuration file specifies the value of the `skip` parameter for any given stage iff (_if and only if_) the stage supports it, i.e. iff the stage inherits from [`SkippableMixin`](https://github.com/BlueBrain/data-validation-framework/blob/main/data_validation_framework/task.py#L781).

 These stages inherit from SkippableMixin, so one can `skip`:
* `class Align(SkippableMixin(True), ElementValidationTask):`
* `class DetectErrors(SkippableMixin(), ElementValidationTask):`
* `class EnsureNeuritesOutsideSoma(SkippableMixin(True), ElementValidationTask):`
* `class ErrorsReport(SkippableMixin(), SetValidationTask):`
* `class ExtractMarkers(SkippableMixin(), ElementValidationTask):`
* `class PlotErrors(SkippableMixin(), ElementValidationTask):`
* `class PlotMarkers(SkippableMixin(), ElementValidationTask):`
* `class PlotMorphologies(SkippableMixin(), ElementValidationTask):`
* `class Recenter(SkippableMixin(), ElementValidationTask):`
* `class Resample(SkippableMixin(), ElementValidationTask):`

These stages don't inherit from SkippableMixin, so one cannot `skip`:
* `class CheckNeurites(ElementValidationTask):`
* `class Collect(ElementValidationTask):`
* `class Curate(ValidationWorkflow):`
* `class Orient(ElementValidationTask):`
* `class Sanitize(ElementValidationTask):`



### Note

After this PR the output of the workflow should not change, this PR just cleans up the configurations to make sure that they correspond to what is actually being run.




## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/morphoclass/issues).
  (if it is not the case, please create an issue first).
- [ ] All CI tests pass. 
